### PR TITLE
Castlecss-core@2.1.0 is now a peerDepencency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/CastleCSS/castlecss-buttons/issues"
   },
   "homepage": "https://github.com/CastleCSS/castlecss-buttons#readme",
-  "dependencies": {
-    "castlecss-core": "^2.0.1"
+  "peerDependencies": {
+    "castlecss-core": "^2.1.0"
   }
 }


### PR DESCRIPTION
# Whats changed?

- Buttons now use min-height instead of height so they can grow
- Buttons darken by 20% of their color on hover
- Castlecss-core@2.1.0 is now a peerDepencency
- Bumb to 1.0
